### PR TITLE
Fetch PR commits from base branch.

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function prCommits(build) {
 
 function getPrCommits(pr) {
     return request({
-        uri: `${GITHUB_API}/repos/${pr.head.repo.full_name}/pulls/${pr.number}/commits`,
+        uri: `${GITHUB_API}/repos/${pr.base.repo.full_name}/pulls/${pr.number}/commits`,
         headers: {
             'Authorization': `token ${GITHUB_TOKEN}`
         }


### PR DESCRIPTION
This PR will try to fix #3 

Previously we try to fetch commit info from the head branch. When dealing with PR from forked repository, the commits API url will not exists.

Turns to fetch commits from the base branch to fix.